### PR TITLE
:bug: chrome 插件：检查面板提前开启无法创建 san pannel

### DIFF
--- a/packages/extensions/src/devtoolsPage.ts
+++ b/packages/extensions/src/devtoolsPage.ts
@@ -26,6 +26,22 @@ function createDevtoolPanelIfNeeded() {
     });
 }
 
-chrome.devtools.network.onNavigated.addListener(createDevtoolPanelIfNeeded);
-createdCheckInterval = setInterval(createDevtoolPanelIfNeeded, checkGap);
-createDevtoolPanelIfNeeded();
+function startPoll() {
+    createdCheckInterval = setInterval(createDevtoolPanelIfNeeded, checkGap);
+    createDevtoolPanelIfNeeded();
+}
+startPoll();
+
+/**
+ *  当页面加载的时候会触发，
+ *  1. 如果 san panel 已经存在，直接退出
+ *  2. 如果不存在，重新轮询
+ */
+function onNavigatedHandler() {
+    if (created) {
+        return;
+    }
+    checkCount = 0;
+    startPoll();
+}
+chrome.devtools.network.onNavigated.addListener(onNavigatedHandler);


### PR DESCRIPTION
@ksky521 
现象：检查面板提前开启，并且开启时间超过 10s 之后，加载 san 页面，没有创建 san panel
修复逻辑：监听 chrome.devtools.network.onNavigated，san 页面加载的时候，重新开启新一轮的 10s 轮询，确保 san 页面的 san.dev.js 加载完成。