### PR TITLE
Ui

### DIFF
--- a/example/src/todo/List.san
+++ b/example/src/todo/List.san
@@ -1,5 +1,6 @@
 <template>
 <div class="todos">
+    <ui-define></ui-define>
     <ui-counter on-counter="dosomething"></ui-counter>
     <div on-click="disposeStore">- dispose store -</div>
     <ui-store-count s-if="disposed"></ui-store-count>
@@ -43,15 +44,17 @@ import service from '../service';
 import { formatDate } from '../filters';
 import { Link } from 'san-router';
 import Counter from '../ui/Counter.san';
-import CountStore from '../ui/CountStore.san'
-import NumCounter from '../ui/NumCounter.san'
+import CountStore from '../ui/CountStore.san';
+import NumCounter from '../ui/NumCounter.san';
+import SanDefine from '../ui/SanDefine.js'
 
 export default {
     components: {
         'router-link': Link,
         'ui-counter': Counter,
         'ui-num-counter': NumCounter,
-        'ui-store-count': CountStore
+        'ui-store-count': CountStore,
+        'ui-define': SanDefine
     },
 
     dosomething() {

--- a/example/src/ui/SanDefine.js
+++ b/example/src/ui/SanDefine.js
@@ -10,11 +10,8 @@ export default san.defineComponent({
     `,
 
     initData() {
-        return {
-        };
+        return {};
     },
 
-    dataTypes: {
-    }
-
+    dataTypes: {}
 });

--- a/example/src/ui/SanDefine.js
+++ b/example/src/ui/SanDefine.js
@@ -1,0 +1,20 @@
+/**
+ * @file
+ */
+import san, {DataTypes} from 'san';
+export default san.defineComponent({
+    template: `
+        <div class="san-define">
+            san.defineComponent
+        </div>
+    `,
+
+    initData() {
+        return {
+        };
+    },
+
+    dataTypes: {
+    }
+
+});

--- a/packages/backend/src/hook.ts
+++ b/packages/backend/src/hook.ts
@@ -80,6 +80,7 @@ export interface DevToolsHookStore {
 export interface Component extends SanComponent<any> {
     el: any;
     id: string;
+    subTag?: string; // 组件名称：低版本 san，用 san.defineComponent 生成的组件并且不是 node_modules 中的组件
     parentId: string;
     idPath: string[];
     tagName: string;

--- a/packages/backend/src/initBackend.ts
+++ b/packages/backend/src/initBackend.ts
@@ -21,7 +21,7 @@ export default function initBackend(hook: DevToolsHook<{}>, bridge: Bridge, glob
     // 3. message 和 event
     communication(hook, bridge);
     // 4. 高亮
-    hook.once('san', () => {
+    hook.on('san', () => {
         setupHighlighter(hook, bridge, global);
     });
     // 5. 监听 frontend 是否已经准备就绪

--- a/packages/backend/src/initBackend.ts
+++ b/packages/backend/src/initBackend.ts
@@ -21,7 +21,9 @@ export default function initBackend(hook: DevToolsHook<{}>, bridge: Bridge, glob
     // 3. message 和 event
     communication(hook, bridge);
     // 4. 高亮
-    setupHighlighter(hook, bridge, global);
+    hook.once('san', () => {
+        setupHighlighter(hook, bridge, global);
+    });
     // 5. 监听 frontend 是否已经准备就绪
     bridge.on('HandShake.frontendReady', () => {
         initHookData(hook);

--- a/packages/backend/src/utils/sanHelper.ts
+++ b/packages/backend/src/utils/sanHelper.ts
@@ -2,7 +2,8 @@ import {Component} from '../hook';
 import CircularJSON from '@shared/utils/circularJSON';
 
 function getComponentName(component: Component) {
-    let name = component && ((component.source && component.source.tagName) || component.constructor.name);
+    // eslint-disable-next-line
+    let name = component && ((component.source && component.source.tagName) || component.subTag || component.constructor.name);
     if (!name || name.length === 1) {
         name = component ? component.tagName : 'Component';
     }

--- a/packages/extensions/src/contentScript/backend.ts
+++ b/packages/extensions/src/contentScript/backend.ts
@@ -37,7 +37,7 @@ if (sanHook) {
     initBackend(hook, bridge, window);
 
     // 版本信息：backend --win--> content-script --port--> background
-    hook.once('san', () => {
+    hook.on('san', () => {
         window.postMessage(
             {
                 source: 'san-detector',

--- a/packages/frontend/src/components/layout/basicLayout.san
+++ b/packages/frontend/src/components/layout/basicLayout.san
@@ -79,7 +79,7 @@
 <style lang="less">
     @gutter-bg-color: rgba(0, 0, 0, 0.04);
     @split-bg-color: #e5e5e5;
-    @split-button-more: 105px;
+    @split-button-more: 30%;
     @split-button-less: 5px;
     .sd-main-wrapper {
         height: 100%;

--- a/packages/frontend/src/views/component/componentInfo/componentInfo.san
+++ b/packages/frontend/src/views/component/componentInfo/componentInfo.san
@@ -6,8 +6,8 @@
                     <img src="../../../icons/logo.svg" />
                 </div>
                 <div class="version">San DevTools</div>
+                <div class="guide">Please select a component to inspect the detailed information.</div>
             </div>
-            <div class="guide">Please select a component to inspect the detailed information.</div>
         </div>
         <div class="sd-detail-wrapper" style="display:{{selectedComponentId?'block':'none'}}">
             <div class="title-wrapper">
@@ -196,9 +196,11 @@
             border-radius: 23px;
             background-color: @color-white;
             box-sizing: border-box;
-            padding: 5vw;
+            padding: 20px 30px;
             text-align: center;
             .devtool-info {
+                height: 100%;
+                overflow: auto;
                 .logo {
                     img {
                         width: 40%;


### PR DESCRIPTION
@ksky521 
BUG1:
满足下面两个条件组件名始终为 ComponentCalss：
1. 低版本 san ，比如：3.6.4 以下
2. 使用 san.defineComponent 定义的组件无法显示组件名称
解决办法：
从 component.subTag 获取组件名称

BUG2: 当视图高度非常小的时候，logo 样式被遮挡
解决办法：logo 滚动可见

优化: highlighter 部分，等待检测到 san 之后再挂载用于高亮的 dom。