### PR TITLE
:bug: chrome插件：未打开检查面板的情况下，页面 reload 的时候，hook 后于 san.js 加载，导致无法获取 b…

### DIFF
--- a/packages/extensions/src/contentScript/contentScript.ts
+++ b/packages/extensions/src/contentScript/contentScript.ts
@@ -9,6 +9,5 @@ if (__DEBUG__) {
     console.log('content_script');
 }
 
-injector.fromExtensionUrl(chrome.runtime.getURL('js/san_devtools_backend.js')).then(() => {
-    relay();
-});
+injector.fromExtensionUrlSync(chrome.runtime.getURL('js/san_devtools_backend.js'));
+relay();


### PR DESCRIPTION
@ksky521

未打开检查面板的情况下，如果 reload 当前 san 页面，会导致当前 san 页面缓存的资源优先加载，从而 backend 无法先于 sanjs 执行，导致无法创建 san panel。

打开检查面板情况正常。