### PR TITLE
4个优化

### DIFF
--- a/packages/backend/src/agents/component/componentTree.ts
+++ b/packages/backend/src/agents/component/componentTree.ts
@@ -6,84 +6,29 @@ import {
 } from '../../utils/sanHelper';
 
 /**
- * 得到当前treeData数组所有节点的 id 列表
- * @param {ComponentTreeData[]} treeData
+ * 当 frontend 主动获取组件树数据的时候生成组件树原始数据数组
+ *
+ * @param {*} hook 页面钩子
+ * @return {Array} 组件数据与类型
  */
-function getIDListFromTreeData(treeData: ComponentTreeData[]) {
-    let ids: string[] = [];
-    if (!treeData) {
-        return ids;
-    }
-    treeData.forEach((data: any) => {
-        data.id && ids.push(data.id);
-    });
-    return ids;
+export function getAllComponentTree(hook: DevToolsHook<{}>) {
+    let treeData = hook.data.treeData;
+    let list = [...treeData];
+    return list.map(item => {
+        if (!item[1]) {
+            return null;
+        }
+        return {type: 'add', data: item[1]};
+    }).filter(Boolean);
 }
 
-export function addToTreeData(rootTreeData: ComponentTreeData[], data: ComponentTreeData) {
-    let nodeTreeData = rootTreeData;
-    let path = data.idPath;
-    let pathLen = path.length;
-    for (let [count, curId] of path.entries()) {
-        let index = getIDListFromTreeData(nodeTreeData).indexOf(curId);
-        if (index < 0) {
-            // 如果当前节点没有则直接插入 treeData
-            if (count === pathLen - 1) {
-                nodeTreeData.push(data);
-                return;
-            }
-            // 如果祖先节点没有则需要创建一个空的父节点，下一次遍历对象是这个空的父节点的 treeData
-            let fakeParentData = {
-                id: curId,
-                parentId: null,
-                displayName: '',
-                extras: [],
-                idPath: [],
-                ownerId: '',
-                tagName: '',
-                treeData: []
-            };
-            nodeTreeData.push(fakeParentData);
-            nodeTreeData = fakeParentData.treeData;
-        } else {
-            // 如果 attached 的当前节点是某个父节点，那么不管是不是空节点，都需要填充一下
-            if (nodeTreeData[index] && nodeTreeData[index].id === data.id) {
-                nodeTreeData[index].parentId = data.parentId;
-                nodeTreeData[index].ownerId = data.ownerId;
-                nodeTreeData[index].tagName = data.tagName;
-                nodeTreeData[index].displayName = data.displayName;
-                nodeTreeData[index].idPath = data.idPath;
-                nodeTreeData[index].extras = data.extras;
-                nodeTreeData[index].mapStates = data.mapStates;
-                nodeTreeData[index].mapActionsKeys = data.mapActionsKeys;
-                nodeTreeData[index].storeName = data.storeName;
-            }
-            nodeTreeData = nodeTreeData[index].treeData;
-        }
-    }
-}
-
-export function deleteFromTreeData(rootTreeData: ComponentTreeData[], data: ComponentTreeData) {
-    let nodeTreeData = rootTreeData;
-    let path = data.idPath;
-    let pathLen = path.length;
-    for (let [count, curId] of path.entries()) {
-        if (!nodeTreeData || nodeTreeData.length === 0) {
-            return;
-        }
-        let index = getIDListFromTreeData(nodeTreeData).indexOf(curId);
-        if (index < 0) {
-            return;
-        }
-        if (count === pathLen - 1) {
-            nodeTreeData.splice(index, 1);
-        }
-        if (nodeTreeData[index]) {
-            nodeTreeData = nodeTreeData[index].treeData ? nodeTreeData[index].treeData : [];
-        }
-    }
-}
-
+/**
+ * 用于 backend 生成数据
+ *
+ * @param {*} hook 页面钩子
+ * @param {*} component 组件实例
+ * @return {Object} 组件数据
+ */
 export function getComponentTree(hook: DevToolsHook<{}>, component: Component) {
     let {id} = component;
     let treeData: ComponentTreeData = {

--- a/packages/backend/src/hook.ts
+++ b/packages/backend/src/hook.ts
@@ -85,7 +85,7 @@ export interface DevToolsHook<T> {
 export interface DevToolsHookData {
     totalCompNums: number;
     selectedComponentId: string;
-    treeData: ComponentTreeData[];
+    treeData: Map<string, ComponentTreeData>;
 }
 export interface DevToolsHookStore {
     stores: any;
@@ -131,7 +131,7 @@ export class DevToolsHook<T> extends EventEmitter {
     data: DevToolsHookData = {
         totalCompNums: 0,
         selectedComponentId: '',
-        treeData: []
+        treeData: new Map()
     };
     // profiler data
     profilerData: Map<string, ProfilerData> = new Map();

--- a/packages/frontend/src/components/loading/loading.san
+++ b/packages/frontend/src/components/loading/loading.san
@@ -4,7 +4,6 @@
     >
         <div
             class="san-devtool-loading-toast-content"
-            style="{{loadingToastContentStyle}}"
         >
             {{loadingToast}}
         </div>
@@ -16,25 +15,9 @@
     import SdInput from '@frontend/components/input/input.san';
     export default {
         dataTypes: {
-            loadingToastContentFromColor: DataTypes.string,
-            loadingToastContentToColor: DataTypes.string,
             loadingToast: DataTypes.string,
             progress: DataTypes.number,
             loading: DataTypes.bool
-        },
-        computed: {
-            loadingToastContentStyle() {
-                let fromColor = this.data.get('loadingToastContentFromColor');
-                let toColor = this.data.get('loadingToastContentToColor');
-                let progress = this.data.get('progress');
-                let leftBound = Math.max(0, progress - 3);
-                let rightBound = Math.min(100, progress + 3);
-                return {
-                    'background-image':
-                        `linear-gradient(to right, ${fromColor} ${leftBound}%,
-                        ${toColor} ${rightBound}%, ${toColor})`
-                };
-            }
         }
     }
 </script>

--- a/packages/frontend/src/components/treeView/treeView.san
+++ b/packages/frontend/src/components/treeView/treeView.san
@@ -17,13 +17,6 @@
             >
             </sand-input>
         </san-tooltip>
-        <sand-loading
-            loadingToastContentFromColor="{{loadingToastContentFromColor}}"
-            loadingToastContentToColor="{{loadingToastContentToColor}}"
-            loadingToast="{{loadingToast}}"
-            progress="{{progress}}"
-            loading="{{loading}}"
-        />
         <div class="sm-tree-view-item-wrapper">
             <slot s-if="dataSource!=='JSON'"></slot>
             <san-tree-view-item
@@ -50,7 +43,6 @@
     import { Icon, Tooltip } from 'santd';
     import TreeViewItem from './treeViewItem.san';
     import SdInput from '@frontend/components/input/input.san';
-    import SdLoading from '@frontend/components/loading/loading.san';
     export default {
         dataTypes: {
             compact: DataTypes.bool,
@@ -61,17 +53,13 @@
             filterBarHintText: DataTypes.string,
             dataSource: DataTypes.oneOf(['ATTRIBUTE', 'JSON']),
             highlighted: DataTypes.bool,
-            treeData: DataTypes.arrayOf(DataTypes.object),
-            loading: DataTypes.bool,
-            loadingToast: DataTypes.string,
-            progress: DataTypes.number
+            treeData: DataTypes.arrayOf(DataTypes.object)
         },
 
         components: {
             'san-icon': Icon,
             'san-tree-view-item': TreeViewItem,
             'sand-input': SdInput,
-            'sand-loading': SdLoading,
             'san-tooltip': Tooltip
         },
 
@@ -87,47 +75,20 @@
                 filterBarHintText: '',
                 dataSource: 'ATTRIBUTE',
                 highlighted: false,
-                loading: true,
-                loadingToast: '',
-                loadingToastContentFromColor: 'rgba(0, 175, 255, 1)',
-                loadingToastContentToColor: '#fff',
-                progress: 0,
                 rootTreeView: true,
-                filterText: '',
-                totalNumsChange: false
+                filterText: ''
             };
         },
 
-        updated() {
-            if (this.data.get('totalNumsChange') || true) {
-                setTimeout(() => {
-                    let totalNums = this.data.get('totalNums');
-                    let type = this.data.get('type');
-                    let curNums = document.querySelectorAll(`.tree-view-type-${type}`).length;
-                    if (totalNums <= 0 || !curNums) {
-                        return;
-                    }
-                    let progress = curNums / totalNums * 100;
-                    this.data.set('progress', progress);
-                }, 60);
-            }
-        },
-
         attached() {
-
+            this.watch('treeData', value => {
+                this.data.set('progress', 90);
+                this.data.set('loading', true);
+            });
         },
 
-        created() {
-            if (!this.data.get('loadingToast')) {
-                this.data.set('loading', false);
-            }
-            this.watch('progress', value => {
-                this.data.set('loading', value < 100);
-                value === 100 && this.data.set('totalNumsChange', false);
-            });
-            this.watch('totalNums', value => {
-                this.data.set('totalNumsChange', true);
-            })
+        updated() {
+            this.dispatch('UI:treeViewUpdated');
         },
 
         messages: {

--- a/packages/frontend/src/index.less
+++ b/packages/frontend/src/index.less
@@ -25,3 +25,9 @@ body #root .sm-tree-view .sm-tree-view-item-wrapper .sm-tree-view-item .sm-tree-
 .santd-btn-primary:hover {
     background: rgba(25, 104, 250, 0.8) !important;
 }
+
+#san-devtools-app {
+    .santd-spin {
+        color: #1890ff;
+    }
+}

--- a/packages/frontend/src/message.ts
+++ b/packages/frontend/src/message.ts
@@ -113,7 +113,6 @@ export default class FrontendReceiver extends EventEmitter {
                 'bridge',
                 'settings',
                 'wsDisconnected',
-                'treeData',
                 'activeTab'
             ]
         });

--- a/packages/frontend/src/store/setTreeData.ts
+++ b/packages/frontend/src/store/setTreeData.ts
@@ -2,37 +2,136 @@
  * @file
  */
 import {builder} from 'san-update';
-
-interface ComponentTreeData {
-    id: string;
-    parentId: string | null;
-    displayName: string;
-    extras: any[];
-    idPath: string[];
-    treeData: ComponentTreeData[];
-    ownerId: string;
-    tagName: string;
-    mapStates?: string[];
-    mapActionsKeys?: string[];
-    storeName?: string;
+import {ComponentTreeData} from 'backend/src/hook';
+interface ComponentTreeInfo{
+    type: 'add' | 'del';
+    data: ComponentTreeData;
 }
 
-interface TreeData {
-    totalCompNums: number;
-    selectedComponentId: string;
-    treeData: ComponentTreeData[];
+/**
+ * 得到当前treeData数组所有节点的 id 列表
+ * @param {ComponentTreeData[]} treeData
+ */
+function getIDListFromTreeData(treeData: ComponentTreeData[]) {
+    let ids: string[] = [];
+    if (!treeData) {
+        return ids;
+    }
+    treeData.forEach((data: any) => {
+        data.id && ids.push(data.id);
+    });
+    return ids;
+}
+
+export function addToTreeData(rootTreeData: ComponentTreeData[], data: ComponentTreeData) {
+    let nodeTreeData = rootTreeData;
+    let path = data.idPath;
+    let pathLen = path.length;
+    for (let [count, curId] of path.entries()) {
+        let index = getIDListFromTreeData(nodeTreeData).indexOf(curId);
+        if (index < 0) {
+            // 如果当前节点没有则直接插入 treeData
+            if (count === pathLen - 1) {
+                nodeTreeData.push(data);
+                return true;
+            }
+            // 如果祖先节点没有则需要创建一个空的父节点，下一次遍历对象是这个空的父节点的 treeData
+            let fakeParentData = {
+                id: curId,
+                parentId: null,
+                displayName: '',
+                extras: [],
+                idPath: [],
+                ownerId: '',
+                tagName: '',
+                treeData: []
+            };
+            nodeTreeData.push(fakeParentData);
+            nodeTreeData = fakeParentData.treeData;
+        } else {
+            // 如果 attached 的当前节点是某个父节点，那么不管是不是空节点，都需要填充一下
+            if (nodeTreeData[index] && nodeTreeData[index].id === data.id) {
+                nodeTreeData[index].parentId = data.parentId;
+                nodeTreeData[index].ownerId = data.ownerId;
+                nodeTreeData[index].tagName = data.tagName;
+                nodeTreeData[index].displayName = data.displayName;
+                nodeTreeData[index].idPath = data.idPath;
+                nodeTreeData[index].extras = data.extras;
+                nodeTreeData[index].mapStates = data.mapStates;
+                nodeTreeData[index].mapActionsKeys = data.mapActionsKeys;
+                nodeTreeData[index].storeName = data.storeName;
+                return true;
+            }
+            nodeTreeData = nodeTreeData[index].treeData;
+        }
+    }
+    return false;
+}
+
+export function deleteFromTreeData(rootTreeData: ComponentTreeData[], data: ComponentTreeData) {
+    let nodeTreeData = rootTreeData;
+    let path = data.idPath;
+    let pathLen = path.length;
+    for (let [count, curId] of path.entries()) {
+        if (!nodeTreeData || nodeTreeData.length === 0) {
+            return false;
+        }
+        let index = getIDListFromTreeData(nodeTreeData).indexOf(curId);
+        if (index < 0) {
+            return false;
+        }
+        if (count === pathLen - 1) {
+            nodeTreeData.splice(index, 1);
+            return true;
+        }
+        if (nodeTreeData[index]) {
+            nodeTreeData = nodeTreeData[index].treeData ? nodeTreeData[index].treeData : [];
+        }
+    }
+    return false;
+}
+
+function generateTreeData(rootTreeData: ComponentTreeData[], info: ComponentTreeInfo) {
+    if (info.type === 'add') {
+        return addToTreeData(rootTreeData, info.data) ? +1 : 0;
+    }
+    else {
+        return deleteFromTreeData(rootTreeData, info.data) ? -1 : 0;
+    }
 }
 
 export const setTreeData = {
     initData: {
-        treeData: null,
-        totalCompNums: 0
+        treeData: [],
+        totalCompNums: 0,
+        generatingTreeData: false
     },
     actions: {
-        setTreeData(data: TreeData) {
+        setTreeData(info: ComponentTreeInfo | ComponentTreeInfo[], {dispatch}: any) {
+            dispatch('setGenerateTreeData', true);
+            setTimeout(() => {
+                dispatch('generateTreeData', info);
+            }, 60);
+        },
+        generateTreeData(info: ComponentTreeInfo | ComponentTreeInfo[], {getState}: any) {
+            let oldTreeData = getState('treeData');
+            let totalCompNums = getState('totalCompNums');
+            let newTreeData = oldTreeData.slice();
+
+            if (!Array.isArray(info)) {
+                totalCompNums += generateTreeData(newTreeData, info);
+            }
+            else {
+                info.forEach(item => {
+                    totalCompNums += generateTreeData(newTreeData, item);
+                });
+            }
             return builder()
-                .set('treeData', data.treeData)
-                .set('totalCompNums', data.totalCompNums);
+                .set('totalCompNums', totalCompNums)
+                .set('treeData', JSON.parse(JSON.stringify(newTreeData)));
+        },
+        setGenerateTreeData(start: boolean) {
+            return builder().set('generatingTreeData', start);
         }
     }
 };

--- a/packages/frontend/src/views/component/component.san
+++ b/packages/frontend/src/views/component/component.san
@@ -25,13 +25,6 @@
                 'sandevtool-component-tree': ComponentTree,
                 'sandevtool-component-info': ComponentInfo,
                 'sd-basic-layout': BasicLayout
-            },
-
-            attached() {
-                this.data.get('bridge').send('Component.getTreeData', '');
-                this.watch('bridge', bridge => {
-                    bridge.send('Component.getTreeData', '');
-                });
             }
         }
     )

--- a/packages/frontend/src/views/component/componentTree/componentTree.san
+++ b/packages/frontend/src/views/component/componentTree/componentTree.san
@@ -1,5 +1,10 @@
 <template>
     <div class="sm-tree-view-wrapper custom">
+        <sand-spin
+            class="sand-spin"
+            tip="{{loadingToast}}"
+            spinning="{{generatingTreeData}}"
+        />
         <san-tree-view
             totalNums="{{totalCompNums}}"
             defaultSelectedIdPath="{{defaultSelectedIdPath}}"
@@ -14,11 +19,6 @@
             initiallyOpen="{{!0}}"
             primaryTogglesNestedTreeView="{{!0}}"
             dataSource="JSON"
-            loadingToast="{{loadingToast}} {{processingComponentInfo}}"
-            loading="{=loading=}"
-            loadingToastContentFromColor="rgba(0, 175, 255, 1)"
-            loadingToastContentToColor="#fff"
-            progress="{=progress=}"
             type="component"
         >
         </san-tree-view>
@@ -27,6 +27,7 @@
 
 <script>
     import san, { DataTypes } from 'san';
+    import { Spin } from 'santd';
     import { connectStore, store } from '@frontend/store/index';
     import TreeView from '@frontend/components/treeView/treeView.san';
 
@@ -36,7 +37,8 @@
         treeData: 'treeData',
         totalCompNums: 'totalCompNums',
         bridge: 'bridge',
-        defaultSelectedIdPath: 'inspectedIdPathStr'
+        defaultSelectedIdPath: 'inspectedIdPathStr',
+        generatingTreeData: 'generatingTreeData'
     })({
         messages: {
             'UI:tree-view-item-click'({ value }) {
@@ -48,10 +50,21 @@
         },
         components: {
             'san-tree-view': TreeView,
+            'sand-spin': Spin
         },
 
         setInspectedId({ idPath }) {
             store.dispatch('setInspectId', idPath);
+        },
+
+        messages: {
+            'UI:treeViewUpdated'() {
+                store.dispatch('setGenerateTreeData', false);
+            }
+        },
+
+        attached() {
+            store.dispatch('setGenerateTreeData', false);
         },
 
         setSelectedComponentBaseInfo(treeData) {
@@ -81,9 +94,7 @@
             return {
                 // 默认不对执行代码进行合并处理
                 maxLengthOfExecutionCodeQueue: 10,
-                loadingToast: 'Building component tree... ',
-                loading: true,
-                processingComponentInfo: ''
+                loadingToast: 'Building component tree... '
             };
         },
 
@@ -97,8 +108,7 @@
             /* state */
             maxLengthOfExecutionCodeQueue: DataTypes.number,
             loadingToast: DataTypes.string,
-            loading: DataTypes.bool,
-            processingComponentInfo: DataTypes.string
+            setGenerateTreeData: DataTypes.bool
         },
     })
 </script>
@@ -108,5 +118,11 @@
         width: 100%;
         height: 100%;
         user-select: none;
+        .sand-spin {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+        }
     }
 </style>

--- a/packages/frontend/src/views/history.san
+++ b/packages/frontend/src/views/history.san
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="san-devtools-history-wrapper">
         <san-devtools-table
             decreasedWidth="{{decreasedWidth}}"
             data="{{data}}"
@@ -12,17 +12,16 @@
             searchTip="Use '.' as separator for search, like: [componentName].[lifecycle]"
         >
         </san-devtools-table>
-        <sand-loading
-            loadingToastContentFromColor="{{loadingToastContentFromColor}}"
-            loadingToastContentToColor="{{loadingToastContentToColor}}"
-            loadingToast="{{loadingToast}}"
-            progress="{{progress}}"
-            loading="{{loading}}"
+        <sand-spin
+            class="sand-spin"
+            tip="{{loadingToast}}"
+            spinning="{{loading}}"
         />
     </div>
 </template>
 <script>
     import san, { DataTypes } from 'san';
+    import { Spin } from 'santd';
     import { connectStore, store } from '@frontend/store/index';
     import DevtoolsTable from '@frontend/components/misc/devtoolsTable.san';
     import SdLoading from '@frontend/components/loading/loading.san';
@@ -57,18 +56,14 @@
                 /* state */
                 data: DataTypes.array,
                 decreasedWidth: DataTypes.number,
-                progress: DataTypes.number,
                 loadingToast: DataTypes.string,
-                loading: DataTypes.bool,
-                loadingToastContentFromColor: DataTypes.string,
-                loadingToastContentToColor: DataTypes.string,
                 filterText: DataTypes.string,
                 bridgeOptions: DataTypes.object,
                 columns: DataTypes.array
             },
             components: {
                 'san-devtools-table': DevtoolsTable,
-                'sand-loading': SdLoading
+                'sand-spin': Spin
             },
             clearHandler() {
                 store.dispatch('clearHistory');
@@ -89,11 +84,8 @@
             initData() {
                 return {
                     decreasedWidth: TIMESTAMP_WIDTH + EVENT_WIDTH + COMPONENT_WIDTH + REST_WIDTH,
-                    progress: 0,
                     loadingToast: 'Building history tree... ',
-                    loading: false, // TODO：假的 loading
-                    loadingToastContentFromColor: 'rgba(0, 175, 255, 1)',
-                    loadingToastContentToColor: '#fff',
+                    loading: false,
                     filterText: '',
                     bridgeOptions: {
                         bridgeName: 'History',
@@ -128,13 +120,11 @@
             },
             attached() {
                 this.watch('historyRecordings', value => {
-                    this.data.set('progress', 90);
                     this.data.set('loading', true);
                 });
             },
             updated() {
                 setTimeout(() => {
-                    this.data.set('progress', 0);
                     this.data.set('loading', false);
                 }, 0);
             }
@@ -142,4 +132,12 @@
     )
 </script>
 <style lang="less">
+.san-devtools-history-wrapper {
+    .sand-spin {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+    }
+}
 </style>

--- a/packages/frontend/src/views/profiler/profilerInfo.san
+++ b/packages/frontend/src/views/profiler/profilerInfo.san
@@ -257,7 +257,6 @@
                 this.watch('profilerTime', value => {
                     // 设置menu选中项
                     let index = value.length - 1 || 0;
-                    console.log('profilerTime', value.length);
                     this.data.set('selectedKeys', [index]);
                 });
                 const flameWidth = document.documentElement.offsetWidth * FlAME_WRAPPER_WIDTH_RATIO - FlAME_WRAPPER_PADDING_WIDTH

--- a/packages/frontend/src/views/store/storeInfo/mutation/mutation.san
+++ b/packages/frontend/src/views/store/storeInfo/mutation/mutation.san
@@ -15,7 +15,7 @@
                                 </span>
                             </san-col>
                             <san-col span="12" s-else>
-                                {{info.value}}
+                                {{info.value === 'undefined' ? '-' : info.value}}
                             </san-col>
                         </san-row>
                     </div>


### PR DESCRIPTION
@ksky521 
1. backend treeData 逻辑移动到 frontend：组件实例数量在1000+，componentTree的数据阻塞ws信道，导致ws.send方法耗时过多（等待ws信道队列空闲的时间）
2. 由于 1 导致无法提前知道组件的总数量，去掉 progress loading
3. store 面板：优化展示 undefined 的问题
4. 去除多余的 getTreeData