### PR TITLE
协议头斜杠丢失导致端上无法链接ws

### DIFF
--- a/packages/san-devtools/src/utils/url.ts
+++ b/packages/san-devtools/src/utils/url.ts
@@ -58,7 +58,7 @@ export function getSocketUrl(urlParts: url.UrlWithParsedQuery, wsPath: string, u
     let wsPort: string | null = (query.wsPort as string) || port;
 
     return url.format({
-        protocol: protocol === 'https:' ? 'wss:' : 'ws:',
+        protocol: protocol === 'https:' ? 'wss://' : 'ws://',
         hostname: wsHost,
         port: wsPort,
         query: urlQuery,


### PR DESCRIPTION
@ksky521 
node模块url.format在web端退化为Url.prototype.format导致协议头反斜杠丢失,最终无法链接ws