### PR TITLE
兼容store2.1.0

### DIFF
--- a/packages/backend/src/agents/store/index.ts
+++ b/packages/backend/src/agents/store/index.ts
@@ -10,8 +10,8 @@ import {
     getStoreData
 } from './storeTree';
 import CircularJSON from '@shared/utils/circularJSON';
+import {storeDecorator} from './versionControl';
 
-let hasChangeStore = false;
 
 export class StoreAgent extends Agent {
     setupHook() {
@@ -29,23 +29,8 @@ export class StoreAgent extends Agent {
              */
             case 'store-default-inited': {
                 let {store} = data;
-                if (!hasChangeStore && !store.log) {
-                    // 如果引入san-devtools则默认给用户的store.log设置为true
-                    let storeProto = Object.getPrototypeOf(store);
-                    let descs = Object.getOwnPropertyDescriptors(storeProto);
-                    hasChangeStore = true;
-                    // AOP handler
-                    for (let desc in descs) {
-                        let oldProtoFn = storeProto[desc];
-                        if (typeof storeProto[desc] !== 'function' || desc === 'constructor') {
-                            continue;
-                        }
-                        storeProto[desc] = function (...args: any) {
-                            !this.log && (this.log = true);
-                            return oldProtoFn.call(this, ...args);
-                        };
-                    }
-                }
+                // 装饰store
+                storeDecorator.handler(store);
                 if (store.name !== '__default__') {
                     console.warn('[SAN_DEVTOOLS]: there is must be something bad has happened in san-store');
                     return;

--- a/packages/backend/src/agents/store/storeTree.ts
+++ b/packages/backend/src/agents/store/storeTree.ts
@@ -194,14 +194,28 @@ function getTimeRange(startTime: number | undefined, endTime: number | undefined
     return `${start}-${end}`;
 }
 
+/**
+ * 获取触发的 action 的原始数据，这里调用 san-store 实例属性与方法，注意版本兼容性处理
+ * @param data
+ * @param storeName store 名称
+ * @return targetStr 改变的 store 的 key
+ */
 function getActionInfo(data: any) {
     let actionId = data.actionId;
-    let actionCtrl = data.store.actionCtrl;
-    return actionCtrl.getById(+actionId);
+    let store = data.store;
+    if (store.actionCtrl) {
+        // san-store 2.0.3 以下 https://github.com/baidu/san-store/releases/tag/2.0.3
+        return store.actionCtrl.getById(+actionId);
+    }
+    else if (store.actionInfos && store._getActionInfo) {
+        // san-store 2.1.0+ https://github.com/baidu/san-store/commit/a8ade597cf8b00906c95adf9c628a9bded7d3d38
+        return store._getActionInfo(actionId);
+    }
+    return null;
 }
 
 /**
- * 获取触发的 action 的基本信息
+ * 获取此次 action 改变了哪些data
  * @param data
  * @param storeName store 名称
  * @return targetStr 改变的 store 的 key

--- a/packages/backend/src/agents/store/versionControl.ts
+++ b/packages/backend/src/agents/store/versionControl.ts
@@ -12,7 +12,6 @@ export const storeDecorator = {
      */
     handler: function (store: Record<string, any>) {
         if (this.canDecorate(store)) {
-            console.log('canDecorate');
             let storeProto = Object.getPrototypeOf(store);
             let descs = Object.getOwnPropertyDescriptors(storeProto);
             this.hasDecorated = true;

--- a/packages/backend/src/agents/store/versionControl.ts
+++ b/packages/backend/src/agents/store/versionControl.ts
@@ -1,0 +1,39 @@
+/**
+ * @file
+ */
+// https://github.com/baidu/san-store/commit/a8ade597cf8b00906c95adf9c628a9bded7d3d38
+
+export const storeDecorator = {
+    hasDecorated: false, // 是否已经装饰
+    /**
+     * 装饰 store 原型上的每个原型函数
+     * 1. 确保在开发环境启用
+     * 2. 兼容低版本san-store2.1.0以下
+     */
+    handler: function (store: Record<string, any>) {
+        if (this.canDecorate(store)) {
+            console.log('canDecorate');
+            let storeProto = Object.getPrototypeOf(store);
+            let descs = Object.getOwnPropertyDescriptors(storeProto);
+            this.hasDecorated = true;
+            // AOP handler
+            for (let desc in descs) {
+                let oldProtoFn = storeProto[desc];
+                if (typeof storeProto[desc] !== 'function' || desc === 'constructor') {
+                    continue;
+                }
+                storeProto[desc] = function (...args: any) {
+                    !this.log && (this.log = true);
+                    return oldProtoFn.call(this, ...args);
+                };
+            }
+        }
+    },
+    /**
+    * 根据 store 实例上是否有特定属性方法来判断是否添加装饰器
+    */
+    canDecorate: function canDecorate(store: Record<string, any>) {
+        let versionOk = !store.actionCtrl || !store.actionCtrl.getById;
+        return !this.hasDecorated && !store.log && versionOk;
+    }
+};


### PR DESCRIPTION
@ksky521 
背景：
1. san-store2.1.0修改了通知san-devtools的条件，导致无法接收san-store的数据：https://github.com/baidu/san-store/commit/4ef82e915e78b83ae38cf8743b1fa9b1e4cb41a9
 2. san-store删除了部分属性，导致无法获取到action详细数据：https://github.com/baidu/san-store/commit/a8ade597cf8b00906c95adf9c628a9bded7d3d38
处理：
1. 处理问题1: 只对于2.1.0以下版本的san-store的Store类的原型方法进行装饰(AOP)，来修改store.log属性为true（在开发环境下如果引用san-devtools则强制接收store数据，避免在上线前忘记修改log为false，或者增加webpack额外的配置）
2. 处理问题2:  获取action详细数据进行兼容